### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Pods/ActionSheetPicker-3.0/README.md
+++ b/Pods/ActionSheetPicker-3.0/README.md
@@ -24,7 +24,7 @@ Please welcome: **ActionSheetPicker-3.0**!
 
 `pod 'ActionSheetPicker-3.0', '~> 2.2.0'` (**iOS 5.1.1-9.x** compatible!)
 
-##ActionSheetPicker = UIPickerView + UIActionSheet ##
+## ActionSheetPicker = UIPickerView + UIActionSheet  ##
 
 ![Animation](Screenshots/example.gif)
 
@@ -101,7 +101,7 @@ NSArray *colors = [NSArray arrayWithObjects:@"Red", @"Green", @"Blue", @"Orange"
 
  
  
-##Installation##
+## Installation ##
 
 ### CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ See [BitmapPlayerViewController.m](https://github.com/ashqal/MD360Player4iOS/blo
 * or QQ Group<br/>
 ![QQ Group](https://cloud.githubusercontent.com/assets/5126517/15381968/5a0e56a2-1db7-11e6-986e-462d96dd5e02.jpeg)
 
-##LICENSE
+## LICENSE
 ```
 Copyright 2016 Asha
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
