### PR TITLE
Fix: vertical dragging now rotates the view correctly

### DIFF
--- a/MDVRLibrary/MDVRLibrary/MD360Director.m
+++ b/MDVRLibrary/MDVRLibrary/MD360Director.m
@@ -95,7 +95,6 @@ static float sNear = 0.7f;
     mModelMatrix = GLKMatrix4Identity;
     
     mCurrentRotation = GLKMatrix4Identity;
-    mCurrentRotation = GLKMatrix4Rotate(mCurrentRotation, GLKMathDegreesToRadians(-mDeltaY + mAngleY), 1.0f, 0.0f, 0.0f);
     
     mCurrentRotation = GLKMatrix4Rotate(mCurrentRotation, GLKMathDegreesToRadians(-mDeltaX + mAngleX), 0.0f, 1.0f, 0.0f);
     
@@ -103,6 +102,8 @@ static float sNear = 0.7f;
     
     // set the accumulated rotation to the result.
     mAccumulatedRotation = mCurrentRotation;
+    
+    mModelMatrix = GLKMatrix4Rotate(mModelMatrix, GLKMathDegreesToRadians(-mDeltaY + mAngleY), 1.0f, 0.0f, 0.0f);
     
     // Rotate the cube taking the overall rotation into account.
     mTemporaryMatrix = GLKMatrix4Multiply(mModelMatrix, mAccumulatedRotation);


### PR DESCRIPTION
Hello! Thank you for your work on this library. I made a small fix that I needed for the project I'm working on, and I thought maybe others could be interested in it.

Before this commit vertical dragging would rotate the sphere without taking into account the current device orientation (Y-rotation) which, I think, is not what the common user would expect. 

Now vertical swipe always moves the camera up/down regardless of the device orientation. It behaves just like the android version of this library.